### PR TITLE
add through migrations, the columns and dependecies

### DIFF
--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Supplier extends Model
+{
+    use HasFactory;
+}

--- a/database/migrations/2023_04_21_111849_create_suppliers_table.php
+++ b/database/migrations/2023_04_21_111849_create_suppliers_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSuppliersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('suppliers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 50);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('suppliers');
+    }
+}

--- a/database/migrations/2023_04_22_095502_create_products_table.php
+++ b/database/migrations/2023_04_22_095502_create_products_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProductsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->text('description', 500)->nullable();
+            $table->float('price', 8, 2)->default(0.00);
+            $table->integer('stock')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('products');
+    }
+}

--- a/database/migrations/2023_04_22_101657_alter_suppliers_new_columns.php
+++ b/database/migrations/2023_04_22_101657_alter_suppliers_new_columns.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterSuppliersNewColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('suppliers', function (Blueprint $table) {
+            $table->string('address', 100)->after('name')->nullable();
+            $table->string('phone', 20)->after('address')->nullable();
+            $table->string('email', 80)->after('phone')->nullable();
+            $table->string('contact_name', 50)->after('email')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('suppliers', function (Blueprint $table) {
+            $table->dropColumn('address');
+            $table->dropColumn('phone');
+            $table->dropColumn('email');
+            $table->dropColumn('contact_name');
+        });
+    }
+}

--- a/database/migrations/2023_04_22_103021_create_product_details_table.php
+++ b/database/migrations/2023_04_22_103021_create_product_details_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProductDetailsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('product_details', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('product_id');
+            $table->float('weight', 8, 2)->default(0.00);
+            $table->float('height', 8, 2)->default(0.00);
+            $table->float('width', 8, 2)->default(0.00);
+            $table->float('depth', 8, 2)->default(0.00);
+            $table->timestamps();
+
+            $table->foreign('product_id')->references('id')->on('products');
+            $table->unique('product_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //drop foreign key
+        Schema::table('product_details', function (Blueprint $table) {
+            $table->dropForeign('product_details_product_id_foreign');
+            $table->dropColumn('product_id');
+        });
+        Schema::dropIfExists('product_details');
+    }
+}

--- a/database/migrations/2023_04_22_145500_craete_measurement_units_table.php
+++ b/database/migrations/2023_04_22_145500_craete_measurement_units_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CraeteMeasurementUnitsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('measurement_units', function (Blueprint $table) {
+            $table->id();
+            $table->string('unit_name', 50);
+            $table->string('unit_symbol', 5);
+            $table->timestamps();
+        });
+
+        Schema::table('product_details', function (Blueprint $table) {
+            $table->unsignedBigInteger('measurement_unit_id');
+            $table->foreign('measurement_unit_id')->references('id')->on('measurement_units');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('product_details', function (Blueprint $table) {
+            $table->dropForeign('product_details_measurement_unit_id_foreign');
+            $table->dropColumn('measurement_unit_id');
+        });
+
+        Schema::dropIfExists('measurement_units');
+    }
+}

--- a/database/migrations/2023_04_22_162056_alter_products_new_columns.php
+++ b/database/migrations/2023_04_22_162056_alter_products_new_columns.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterProductsNewColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->integer('maximum_stock')->nullable();
+            $table->integer('minimum_stock')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('maximum_stock');
+            $table->dropColumn('minimum_stock');
+        });
+    }
+}

--- a/database/migrations/2023_04_22_162514_adjust_product_branches.php
+++ b/database/migrations/2023_04_22_162514_adjust_product_branches.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AdjustProductBranches extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('branches', function (Blueprint $table) {
+            $table->id();
+            $table->string('branch_name');
+            $table->timestamps();
+        });
+        
+        Schema::create('product_branches', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('product_id');
+            $table->unsignedBigInteger('branch_id');
+            $table->decimal('price', 8, 2)->default(0.00);
+            $table->integer('maximum_stock')->nullable();
+            $table->integer('minimum_stock')->nullable(); 
+            $table->timestamps();
+
+            //foreign keys
+            $table->foreign('product_id')->references('id')->on('products')->onDelete('cascade');
+            $table->foreign('branch_id')->references('id')->on('branches')->onDelete('cascade');
+
+        });
+
+        //remove from products table price, maximum_stock, minimum_stock
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn(['price', 'maximum_stock', 'minimum_stock']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->decimal('price', 8, 2)->default(0.00);
+            $table->integer('maximum_stock')->nullable();
+            $table->integer('minimum_stock')->nullable();
+        });
+
+        Schema::dropIfExists('product_branches');
+        Schema::dropIfExists('branches');
+    }
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -99,14 +99,13 @@ nav a {
     text-decoration: none;
     padding: 14px 16px;
     color: #333;
-    border-radius: 50%;
+    transition: 0.5s;
 }
 
 nav a:hover {
     color: #fff;
     background-color: #268fd0;
     transition: 0.5s;
-    border-radius: 50%;
 }
 
 .featured-content {


### PR DESCRIPTION
### This pull request adds new database migrations forcontacts, suppliers, products, and their respective dependencies. The following migrations were created:

- `create_web_contacts_table`: This migration creates a table for web contacts.
- `create_suppliers_table`: This migration creates a table for suppliers.
- `create_products_table`: This migration creates a table for products.
- `alter_suppliers_new_columns`: This migration adds new columns to the `suppliers` table.
- `create_product_details_table`: This migration creates a table for product details.
- `create_measurement_units_table`: This migration creates a table for measurement units.
- `alter_products_new_columns`: This migration adds new columns to the `products` table.
- `adjust_product_branches`: Adds new tables for *branches* and *product branches*, removes columns from products table and creates foreign key relationships between the tables.

All of these migrations were run in batch 1. During testing, I rolled back the migrations and then ran them again, which is why they are all in the same batch.

Thank you for considering this pull request!


| Ran? | Migration                                             | Batch |
|------|-------------------------------------------------------|-------|
| Yes  | 2014_10_12_000000_create_users_table                  | 1     |
| Yes  | 2014_10_12_100000_create_password_resets_table        | 1     |
| Yes  | 2019_08_19_000000_create_failed_jobs_table            | 1     |
| Yes  | 2019_12_14_000001_create_personal_access_tokens_table | 1     |
| Yes  | 2023_04_21_101508_create_web_contacts_table           | 1     |
| Yes  | 2023_04_21_111849_create_suppliers_table              | 1     |
| Yes  | 2023_04_22_095502_create_products_table               | 1     |
| Yes  | 2023_04_22_101657_alter_suppliers_new_columns         | 1     |
| Yes  | 2023_04_22_103021_create_product_details_table        | 1     |
| Yes  | 2023_04_22_145500_craete_measurement_units_table      | 1     |
| Yes  | 2023_04_22_162056_alter_products_new_columns          | 1     |
| Yes  | 2023_04_22_162514_adjust_product_branches             | 1     |

All tables in this pull request are at batch 1 because I rolled back the migrations to test the code and then ran the migrations again.
